### PR TITLE
Fixed missing commas in imports

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -304,8 +304,8 @@ import {
   gridColumn,
   gridRow,
   gridAutoFlow,
-  gridAutoColumns
-  gridAutoRows
+  gridAutoColumns,
+  gridAutoRows,
   gridTemplateColumns,
   gridTemplateRows,
   gridTemplateAreas,


### PR DESCRIPTION
Going through the docs and noticed missing commas in the import statement.